### PR TITLE
Added options to change the Power and Mode Values

### DIFF
--- a/MQTT.md
+++ b/MQTT.md
@@ -35,8 +35,8 @@ When writing data, the retain flag shall be 'false'!
 
 topic|r/w|value|comment
 -----|---|-----|------
-Power|r/w|"On", "Off"|
-Mode|r/w|"Auto", "Dry", "Cool", "Fan" or "Heat"
+Power|r/w|"On", "Off"|Override these if needed with POWER_ON and POWER_OFF 
+Mode|r/w|"Auto", "Dry", "Cool", "Fan" or "Heat"|Override these if needed with MODE_AUTO, MODE_DRY etc
 Tsetpoint|r/w|18 ... 30|Target room temperature (integer) in °C
 Fan|r/w|1 ... 4|Fan level
 Vanes|r/w|1,2,3,4,"Swing","?"|Vanes up/down position <sup>1</sup>

--- a/src/MHI-AC-Ctrl.h
+++ b/src/MHI-AC-Ctrl.h
@@ -17,14 +17,14 @@
 #define TEMP_MEASURE_PERIOD 30 // period in seconds for temperature measurement, enter 0 if you don't use the DS1820 
 
 //Values which will be published/read on MQTT
-#define POWER_ON = "On";
-#define POWER_OFF = "Off";
-#define MODE_AUTO = "Auto";
-#define MODE_DRY = "Dry";
-#define MODE_COOL = "Cool";
-#define MODE_FAN = "Fan";
-#define MODE_HEAT = "Heat";
-#define MODE_ERROR = "Stop";
+#define POWER_ON "On"
+#define POWER_OFF "Off"
+#define MODE_AUTO "Auto"
+#define MODE_DRY "Dry"
+#define MODE_COOL "Cool"
+#define MODE_FAN "Fan"
+#define MODE_HEAT "Heat"
+#define MODE_ERROR "Stop"
 
 // comment out the data you are not interested, but at least one row must be used.
 const byte opdata[][5] {

--- a/src/MHI-AC-Ctrl.h
+++ b/src/MHI-AC-Ctrl.h
@@ -23,6 +23,7 @@
 #define MODE_COOL = "Cool";
 #define MODE_FAN = "Fan";
 #define MODE_HEAT = "Heat";
+#define MODE_ERROR = "Stop";
 
 // comment out the data you are not interested, but at least one row must be used.
 const byte opdata[][5] {
@@ -102,21 +103,21 @@ void eval_op_mode(char mqtt_msg[], byte db10) {
   switch (db10 & 0x1f) {  // 0x10=Auto, 0x11=Dry, 0x12=Cold, 0x13=Fan, 0x14=heat
     case 0x10:
       if ((db10 & 0x30) == 0x30)
-        strcpy(mqtt_msg, "Stop"); // for error operating data
+        strcpy(mqtt_msg, MODE_ERROR); // for error operating data
       else
-        strcpy(mqtt_msg, "Auto"); // for operating data
+        strcpy(mqtt_msg, MODE_AUTO); // for operating data
       break;
     case 0x11:
-      strcpy(mqtt_msg, "Dry");
+      strcpy(mqtt_msg, MODE_DRY);
       break;
     case 0x12:
-      strcpy(mqtt_msg, "Cool");
+      strcpy(mqtt_msg, MODE_COOL);
       break;
     case 0x13:
-      strcpy(mqtt_msg, "Fan");
+      strcpy(mqtt_msg, MODE_FAN);
       break;
     case 0x14:
-      strcpy(mqtt_msg, "Heat");
+      strcpy(mqtt_msg, MODE_HEAT);
       break;
   }
 }

--- a/src/MHI-AC-Ctrl.h
+++ b/src/MHI-AC-Ctrl.h
@@ -15,6 +15,15 @@
 
 #define TEMP_MEASURE_PERIOD 30 // period in seconds for temperature measurement, enter 0 if you don't use the DS1820 
 
+//Values which will be published/read on MQTT
+#define POWER_ON = "On";
+#define POWER_OFF = "Off";
+#define MODE_AUTO = "Auto";
+#define MODE_DRY = "Dry";
+#define MODE_COOL = "Cool";
+#define MODE_FAN = "Fan";
+#define MODE_HEAT = "Heat";
+
 // comment out the data you are not interested, but at least one row must be used.
 const byte opdata[][5] {
   { 0xc0, 0x02, 0xff, 0xff, 0xff },  //  1 "MODE"

--- a/src/MHI-AC-Ctrl.h
+++ b/src/MHI-AC-Ctrl.h
@@ -3,12 +3,13 @@
 #define WIFI_SSID "your SSID"
 #define WIFI_PASSWORD "your WiFi password"
 #define HOSTNAME "MHI-AC-Ctrl"
+#define OTA_NAME "MHI-AC-Ctrl-Living-Room"          // name to display when shown in a list of devices available for OTA updates
+#define MQTT_PREFIX HOSTNAME "/Living-Room/"        // basic prefix used for publishing AC data, good for a room name
 
 #define MQTT_SERVER "ds218p"                        // broker name or IP address of the broker
 #define MQTT_PORT 1883                              // port number used by the broker
 #define MQTT_USER ""                                // if authentication is not used, leave it empty
 #define MQTT_PASSWORD ""                            // if authentication is not used, leave it empty
-#define MQTT_PREFIX HOSTNAME "/"                    // basic prefix used for publishing AC data
 #define MQTT_SET_PREFIX MQTT_PREFIX "set/"          // prefix for subscribing set commands
 #define MQTT_OP_PREFIX MQTT_PREFIX "OpData/"        // prefix for publishing operating data
 #define MQTT_ERR_OP_PREFIX MQTT_PREFIX "ErrOpData/" // prefix for publishing operating data from last error
@@ -124,7 +125,7 @@ void eval_op_mode(char mqtt_msg[], byte db10) {
 
 
 void setupOTA() {
-  ArduinoOTA.setHostname(HOSTNAME);
+  ArduinoOTA.setHostname(OTA_NAME);
   ArduinoOTA.onStart([]() {
     String type;
     if (ArduinoOTA.getCommand() == U_FLASH) {

--- a/src/MHI-AC-Ctrl.ino
+++ b/src/MHI-AC-Ctrl.ino
@@ -2,6 +2,8 @@
 // read + write data via SPI controlled by MQTT
 #include "MHI-AC-Ctrl.h"
 
+
+
 bool sync = 0;
 byte rx_SPIframe[20];
 bool updateMQTTStatus=true;
@@ -81,12 +83,12 @@ void MQTT_subscribe_callback(char* topic, byte* payload, unsigned int length) {
 
   if (strcmp(topic, MQTT_SET_PREFIX "Power") == 0) {
     new_Power = rx_SPIframe[DB0] | 0b11;
-    if (strcmp(payload_str, "On") == 0) {
+    if (strcmp(payload_str, POWER_ON) == 0) {
       set_Power = true;
       new_Power = 0b11;
       publish_cmd_ok();
     }
-    else if (strcmp(payload_str, "Off") == 0) {
+    else if (strcmp(payload_str, POWER_OFF) == 0) {
       set_Power = true;
       new_Power = 0b10;
       publish_cmd_ok();
@@ -95,27 +97,27 @@ void MQTT_subscribe_callback(char* topic, byte* payload, unsigned int length) {
       publish_cmd_invalidparameter();
   }
   else if (strcmp(topic, MQTT_SET_PREFIX "Mode") == 0) {
-    if (strcmp(payload_str, "Auto") == 0) {
+    if (strcmp(payload_str, MODE_AUTO) == 0) {
       set_Mode = true;
       new_Mode = 0b00100000;
       publish_cmd_ok();
     }
-    else if (strcmp(payload_str, "Dry") == 0) {
+    else if (strcmp(payload_str, MODE_DRY) == 0) {
       set_Mode = true;
       new_Mode = 0b00100100;
       publish_cmd_ok();
     }
-    else if (strcmp(payload_str, "Cool") == 0) {
+    else if (strcmp(payload_str, MODE_COOL) == 0) {
       set_Mode = true;
       new_Mode = 0b00101000;
       publish_cmd_ok();
     }
-    else if (strcmp(payload_str, "Fan") == 0) {
+    else if (strcmp(payload_str, MODE_FAN) == 0) {
       set_Mode = true;
       new_Mode = 0b00101100;
       publish_cmd_ok();
     }
-    else if (strcmp(payload_str, "Heat") == 0) {
+    else if (strcmp(payload_str, MODE_HEAT) == 0) {
       set_Mode = true;
       new_Mode = 0b00110000;
       publish_cmd_ok();
@@ -405,28 +407,28 @@ void loop() {
         if (updateMQTTStatus | ((rx_SPIframe[DB0] & 0x01) != power_old)) { // Power
           power_old = rx_SPIframe[DB0] & 0x01;
           if (power_old == 0)
-            MQTTclient.publish(MQTT_PREFIX "Power", "Off", true);
+            MQTTclient.publish(MQTT_PREFIX "Power", POWER_OFF, true);
           else
-            MQTTclient.publish(MQTT_PREFIX "Power", "On", true);
+            MQTTclient.publish(MQTT_PREFIX "Power", POWER_ON, true);
         }
 
         if (updateMQTTStatus | ((rx_SPIframe[DB0] & 0x1c) != mode_old)) { // Mode
           mode_old = rx_SPIframe[DB0] & 0x1c;
           switch (mode_old) {
             case 0x00:
-              MQTTclient.publish(MQTT_PREFIX "Mode", "Auto", true);
+              MQTTclient.publish(MQTT_PREFIX "Mode", MODE_AUTO, true);
               break;
             case 0x04:
-              MQTTclient.publish(MQTT_PREFIX "Mode", "Dry", true);
+              MQTTclient.publish(MQTT_PREFIX "Mode", MODE_DRY, true);
               break;
             case 0x08:
-              MQTTclient.publish(MQTT_PREFIX "Mode", "Cool", true);
+              MQTTclient.publish(MQTT_PREFIX "Mode", MODE_COOL, true);
               break;
             case 0x0c:
-              MQTTclient.publish(MQTT_PREFIX "Mode", "Fan", true);
+              MQTTclient.publish(MQTT_PREFIX "Mode", MODE_FAN, true);
               break;
             case 0x10:
-              MQTTclient.publish(MQTT_PREFIX "Mode", "Heat", true);
+              MQTTclient.publish(MQTT_PREFIX "Mode", MODE_HEAT, true);
               break;
             default:
               MQTTclient.publish(MQTT_PREFIX "Mode", "invalid", true);


### PR DESCRIPTION
Hi there,

I'm trying to integrate with home assistant, and the default thermostat in that does not support the Power and Mode values you've got in your build. I added these as variables which can be overridden.
E.g. home assistant uses "OFF" and "ON" for Power, and there is not a very simple way of mapping these inbound and outbound to "Off" and "On". Easier just to use "OFF" and "ON" in MHI-AC-Ctrl

I also added a room name to the MQTT_PREFIX to make it more obvious what the syntax should be, so you can keep your HOSTNAME the same for each unit to group all the units together.
Lastly I added a separate OTA_NAME so that if you have multiple units in different rooms you can differentiate if the HOSTNAME value is the same for each.