### PR TITLE
Supported model update (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ I assume that all AC units of the type "SRK xx ZS-S" / "SRC xx ZS-S" are support
 
 - SRF xx ZJX-S1
 - SRF xx ZMX-S
+- SRF xx ZMXA-S
 - SRK xx ZJ-S
 - SRK xx ZM-S
 - SRK xx ZS-S
@@ -25,6 +26,7 @@ I assume that all AC units of the type "SRK xx ZS-S" / "SRC xx ZS-S" are support
 - SRK xx ZSX-W
 - SRK xx ZS-W
 - SRR xx ZM-S
+- SRK xx ZMXA-S
 
 Unsupported models:
 


### PR DESCRIPTION
Adding SRF XX ZMXA-S and SRK XX ZMXA-S model families to supported models list.

Specific models tested:
* SRF50ZMXA-S
* SRK50ZMXA-S
* SRK35ZMXA-S
* SRK25ZMXA-S

The SRK units are connected to multi-head compressors. SRF to a dedicated compressor.

These models were purchased new in the Australian market in 2021.