### PR TITLE
Added enhancing Tsetpoint resolution when using .5 degrees

### DIFF
--- a/SW-Configuration.md
+++ b/SW-Configuration.md
@@ -78,12 +78,10 @@ Troom|r/w|0 ... 35|Room temperature (float) in °C, resolution is 0.25°C  <sup>
 Tds1820|r|-40 .. 85|Temperature (float) by the additional DS18x20 sensor in °C, resolution is 0.5°C  <sup>3</sup>
 Errorcode|r|0 .. 255|error code (unsigned int)
 ErrOpData|w||triggers the reading of last error operating data
-Troom_offset|r|0.00 .. 0.50|Offset in °C used for Troom when ENHANCED RESOLUTION is used  <sup>4</sup>
 
 <sup>1</sup> When the last command was received via the infrared remote control then the Vanes status is unknown and the "?" is published.   
 <sup>2</sup> Please compare with section [Room temperature](#room-temperature) for writing.   
 <sup>3</sup> Only available when a DS18x20 is connected, please see the description in [Hardware.md](Hardware.md) and in section [External Temperature Sensor Settings](#external-temperature-sensor-settings-supporth).
-<sup>4</sup> See the description in section [Enhance resolution of setpoint](#Enhance-resolution-of-setpoint-supporth).
 
 Additionally, the following program status topics are available:
 
@@ -171,10 +169,9 @@ The AC is only accepting a setpoint in x.0 degrees. If you send x.5 degrees, the
                                                     // this will simulate .x degrees resolution
 ```
 If you now send x.5 degrees as setpoint, still the setpoint on the AC will be (x+1). But when sending the received Troom (from MQTT or the external temperature sensor) to the AC, Troom with an offset of .5 degrees will be send to the AC. This way the AC will increase the temperature in the room with .5 degrees instead of 1 degree.
+The MQTT topic Troom will show (like before) the Troom received by the AC (including the offset). 
 
-The MQTT topic Troom_offset displays the offset which is added to Troom sent to the AC. The topic Troom will show (like before) the Troom received by the AC (including the offset). 
-
-For example: when setpoint is 20.5, MQTT topic Troom_offset will display 0.5. When Troom 19.5 is received (from MQTT or DS18x20), Troom sent to the AC will be 20.0. Topic Troom will also show 20.0.
+For example: when setpoint is 20.5. When Troom 19.5 is received (from MQTT or DS18x20), Troom sent to the AC will be 20.0. Topic Troom will also show 20.0.
 
 # Advanced settings
 

--- a/SW-Configuration.md
+++ b/SW-Configuration.md
@@ -171,7 +171,8 @@ The AC is only accepting a setpoint in x.0 degrees. If you send x.5 degrees, the
                                                     // this will simulate .x degrees resolution
 ```
 If you now send x.5 degrees as setpoint, still the setpoint on the AC will be (x+1). But when sending the received Troom (from MQTT or the external temperature sensor) to the AC, Troom with an offset of .5 degrees will be send to the AC. This way the AC will increase the temperature in the room with .5 degrees instead of 1 degree.
-The MQTT topic Troom_offset displays the offset which is added to Troom sent to the AC. The topic Troom will show (like before) the the Troom received by the AC (including the offset). 
+
+The MQTT topic Troom_offset displays the offset which is added to Troom sent to the AC. The topic Troom will show (like before) the Troom received by the AC (including the offset). 
 
 For example: when setpoint is 20.5, MQTT topic Troom_offset will display 0.5. When Troom 19.5 is received (from MQTT or DS18x20), Troom sent to the AC will be 20.0. Topic Troom will also show 20.0.
 

--- a/SW-Configuration.md
+++ b/SW-Configuration.md
@@ -78,6 +78,7 @@ Troom|r/w|0 ... 35|Room temperature (float) in °C, resolution is 0.25°C  <sup>
 Tds1820|r|-40 .. 85|Temperature (float) by the additional DS18x20 sensor in °C, resolution is 0.5°C  <sup>3</sup>
 Errorcode|r|0 .. 255|error code (unsigned int)
 ErrOpData|w||triggers the reading of last error operating data
+Troom_offset|r|0.00 .. 0.50|Offset in °C for Troom used when ENHANCED RESOLUTION is used
 
 <sup>1</sup> When the last command was received via the infrared remote control then the Vanes status is unknown and the "?" is published.   
 <sup>2</sup> Please compare with section [Room temperature](#room-temperature) for writing.   

--- a/SW-Configuration.md
+++ b/SW-Configuration.md
@@ -78,11 +78,12 @@ Troom|r/w|0 ... 35|Room temperature (float) in °C, resolution is 0.25°C  <sup>
 Tds1820|r|-40 .. 85|Temperature (float) by the additional DS18x20 sensor in °C, resolution is 0.5°C  <sup>3</sup>
 Errorcode|r|0 .. 255|error code (unsigned int)
 ErrOpData|w||triggers the reading of last error operating data
-Troom_offset|r|0.00 .. 0.50|Offset in °C for Troom used when ENHANCED RESOLUTION is used
+Troom_offset|r|0.00 .. 0.50|Offset in °C used for Troom when ENHANCED RESOLUTION is used  <sup>4</sup>
 
 <sup>1</sup> When the last command was received via the infrared remote control then the Vanes status is unknown and the "?" is published.   
 <sup>2</sup> Please compare with section [Room temperature](#room-temperature) for writing.   
 <sup>3</sup> Only available when a DS18x20 is connected, please see the description in [Hardware.md](Hardware.md) and in section [External Temperature Sensor Settings](#external-temperature-sensor-settings-supporth).
+<sup>4</sup> See the description in section [Enhance resolution of setpoint](#Enhance-resolution-of-setpoint-supporth).
 
 Additionally, the following program status topics are available:
 
@@ -161,6 +162,18 @@ But when you uncomment the following line, then the AC is switched on, once you 
 ```
 //#define POWERON_WHEN_CHANGING_MODE true           // uncomment it to switch on the AC when the mode (heat, cool, dry etc.) is changed
 ```
+
+## Enhance resolution of setpoint ([support.h](src/support.h))
+The AC is only accepting a setpoint in x.0 degrees. If you send x.5 degrees, the AC will convert this to (x+1).0 degrees. So using .5 degrees as a setpoint will increase the setpoint on the AC not with .5 degrees but with 1 degree. This behaviour can be changed with: 
+```
+#define ENHANCED_RESOLUTION true                    // when using Tsetpoint with x.5 degrees, airco will use (x+1).0 setpoint
+                                                    // uncomment this to compensatie (offset) Troom for this.
+                                                    // this will simulate .x degrees resolution
+```
+If you now send x.5 degrees as setpoint, still the setpoint on the AC will be (x+1). But when sending the received Troom (from MQTT or the external temperature sensor) to the AC, Troom with an offset of .5 degrees will be send to the AC. This way the AC will increase the temperature in the room with .5 degrees instead of 1 degree.
+The MQTT topic Troom_offset displays the offset which is added to Troom sent to the AC. The topic Troom will show (like before) the the Troom received by the AC (including the offset). 
+
+For example: when setpoint is 20.5, MQTT topic Troom_offset will display 0.5. When Troom 19.5 is received (from MQTT or DS18x20), Troom sent to the AC will be 20.0. Topic Troom will also show 20.0.
 
 # Advanced settings
 

--- a/src/MHI-AC-Ctrl-core.cpp
+++ b/src/MHI-AC-Ctrl-core.cpp
@@ -20,8 +20,6 @@ void MHI_AC_Ctrl_Core::reset_old_values() {  // used e.g. when MQTT connection t
   status_tsetpoint_old = 0x00;
   status_errorcode_old = 0xff;
 
-  Troom_offset_old = 999.0;
-
   // old operating data
   op_0x94_old = 0xff;
   op_mode_old = 0xff;
@@ -506,12 +504,6 @@ int MHI_AC_Ctrl_Core::loop(int max_time_ms) {
         m_cbiStatus->cbiStatusFunction(opdata_unknown, MOSI_frame[DB10] << 8 | MOSI_frame[DB9]);
         Serial.printf("Unknown operating data, MOSI_frame[DB9]=%i MOSI_frame[D10]=%i\n", MOSI_frame[DB9], MOSI_frame[DB10]);
     }
-  }
-
-  // Troom_offset is not received from but calculated when Tsetpoint x.5 degrees and ENHANCED_RESOLUTION is used
-  if (Troom_offset != Troom_offset_old) {
-	  Troom_offset_old = Troom_offset;
-	  m_cbiStatus->cbiStatusFunction(troom_offset, (int)(Troom_offset*1000.0));
   }
 
   return call_counter;

--- a/src/MHI-AC-Ctrl-core.h
+++ b/src/MHI-AC-Ctrl-core.h
@@ -2,6 +2,12 @@
 
 #include <Arduino.h>
 
+//#define DISABLE_FILTER_TROOM true                   // only Troom delta > 0.25 degrees are reported in MQTT
+                                                    // uncomment this to report delta > 0.00
+
+// *** The configuration ends here ***
+
+
 // comment out the data you are not interested, but at least leave the last dummy row
 const byte opdata[][2] PROGMEM = {
   //{ 0xc0, 0x94},  //  ? "opdata_0x94", background is unknown.
@@ -63,6 +69,7 @@ enum ACType {   // Type enum
 
 enum ACStatus { // Status enum
   status_power = type_status, status_mode, status_fan, status_vanes, status_troom, status_tsetpoint, status_errorcode,
+  troom_offset,
   opdata_mode = type_opdata, opdata_0x94, opdata_tsetpoint, opdata_return_air, opdata_outdoor, opdata_tho_r1, opdata_iu_fanspeed, opdata_thi_r1, opdata_thi_r2, opdata_thi_r3,
   opdata_ou_fanspeed, opdata_total_iu_run, opdata_total_comp_run, opdata_comp, opdata_ct, opdata_td,
   opdata_tdsh, opdata_protection_no, opdata_defrost, opdata_ou_eev1, opdata_unknown,
@@ -130,6 +137,10 @@ class MHI_AC_Ctrl_Core {
     bool request_erropData = false;
     byte new_Troom = 0xff;
 
+    float Troom_offset = 0.0;
+    float Troom_offset_old = 999.0;
+
+
     CallbackInterface_Status *m_cbiStatus;
 
   public:
@@ -148,4 +159,7 @@ class MHI_AC_Ctrl_Core {
     void set_vanes(uint vanes);           // set the vanes horizontal position (or swing)
     void set_troom(byte temperature);     // set the room temperature used by AC
     void request_ErrOpData();             // request that the AC provides the error data
+    float get_troom_offset();             // get troom offset, only usefull when ENHANCED_RESOLUTION is used
+    void set_troom_offset(float offset);  // set troom offset, only usefull when ENHANCED_RESOLUTION is used
+
 };

--- a/src/MHI-AC-Ctrl-core.h
+++ b/src/MHI-AC-Ctrl-core.h
@@ -69,7 +69,6 @@ enum ACType {   // Type enum
 
 enum ACStatus { // Status enum
   status_power = type_status, status_mode, status_fan, status_vanes, status_troom, status_tsetpoint, status_errorcode,
-  troom_offset,
   opdata_mode = type_opdata, opdata_0x94, opdata_tsetpoint, opdata_return_air, opdata_outdoor, opdata_tho_r1, opdata_iu_fanspeed, opdata_thi_r1, opdata_thi_r2, opdata_thi_r3,
   opdata_ou_fanspeed, opdata_total_iu_run, opdata_total_comp_run, opdata_comp, opdata_ct, opdata_td,
   opdata_tdsh, opdata_protection_no, opdata_defrost, opdata_ou_eev1, opdata_unknown,
@@ -138,8 +137,7 @@ class MHI_AC_Ctrl_Core {
     byte new_Troom = 0xff;
 
     float Troom_offset = 0.0;
-    float Troom_offset_old = 999.0;
-
+    
 
     CallbackInterface_Status *m_cbiStatus;
 

--- a/src/MHI-AC-Ctrl.h
+++ b/src/MHI-AC-Ctrl.h
@@ -23,8 +23,6 @@
 #define TOPIC_TSETPOINT "Tsetpoint"
 #define TOPIC_ERRORCODE "Errorcode"
 
-#define TOPIC_TROOM_OFFSET "Troom_offset"
-
 #define TOPIC_UNKNOWN "unknown"
 #define TOPIC_0X94 "OPDATA_0x94"
 #define TOPIC_RETURNAIR "RETURN-AIR"

--- a/src/MHI-AC-Ctrl.h
+++ b/src/MHI-AC-Ctrl.h
@@ -23,6 +23,8 @@
 #define TOPIC_TSETPOINT "Tsetpoint"
 #define TOPIC_ERRORCODE "Errorcode"
 
+#define TOPIC_TROOM_OFFSET "Troom_offset"
+
 #define TOPIC_UNKNOWN "unknown"
 #define TOPIC_0X94 "OPDATA_0x94"
 #define TOPIC_RETURNAIR "RETURN-AIR"

--- a/src/MHI-AC-Ctrl.ino
+++ b/src/MHI-AC-Ctrl.ino
@@ -121,6 +121,9 @@ void MQTT_subscribe_callback(const char* topic, byte* payload, unsigned int leng
   }
   else if (strcmp_P(topic, PSTR(MQTT_SET_PREFIX TOPIC_TROOM)) == 0) {
     float f=atof((char*)payload);
+#ifdef ENHANCED_RESOLUTION
+    f = f + mhi_ac_ctrl_core.get_troom_offset() ;  // increase Troom with current offset to compensate higher setpoint
+#endif
     if ((f > -10) & (f < 48)) {
       room_temp_set_timeout_Millis = millis();  // reset timeout
       troom_was_set_by_MQTT=true;
@@ -154,6 +157,11 @@ class StatusHandler : public CallbackInterface_Status {
     void cbiStatusFunction(ACStatus status, int value) {
       char strtmp[10];
       static int mode_tmp = 0xff;
+#ifdef ENHANCED_RESOLUTION      
+      float offset = mhi_ac_ctrl_core.get_troom_offset();
+      float tmp_value;
+#endif
+
       //Serial.printf_P(PSTR("status=%i value=%i\n"), status, value);
       switch (status) {
         case status_power:
@@ -244,7 +252,16 @@ class StatusHandler : public CallbackInterface_Status {
           dtostrf((value - 61) / 4.0, 0, 2, strtmp);
           output_P(status, PSTR(TOPIC_TROOM), strtmp);
           break;
+        case troom_offset:
+          dtostrf(value/1000.0, 0, 2, strtmp);
+          output_P(status, PSTR(TOPIC_TROOM_OFFSET), strtmp);
+          break;	   
         case status_tsetpoint:
+#ifdef ENHANCED_RESOLUTION
+          tmp_value = (value & 0x7f)/ 2.0;
+          offset = round(tmp_value)  - tmp_value;  // Calculate offset when setpoint is changed
+          mhi_ac_ctrl_core.set_troom_offset(offset);
+#endif          
         case opdata_tsetpoint:
         case erropdata_tsetpoint:
           dtostrf((value & 0x7f)/ 2.0, 0, 1, strtmp);
@@ -391,6 +408,12 @@ void loop() {
   
 #if TEMP_MEASURE_PERIOD > 0
   byte ds18x20_value = getDs18x20Temperature(25);
+#ifdef ENHANCED_RESOLUTION
+  float offset = mhi_ac_ctrl_core.get_troom_offset();
+  byte tmp = offset*4;
+  ds18x20_value = ds18x20_value + tmp;   // add offset
+#endif
+
 #ifdef ROOM_TEMP_DS18X20
   if(ds18x20_value != ds18x20_value_old) {
     if ((ds18x20_value > 21) & (ds18x20_value < 253)) {  // use only values -10°C < T < 48°C

--- a/src/MHI-AC-Ctrl.ino
+++ b/src/MHI-AC-Ctrl.ino
@@ -252,10 +252,6 @@ class StatusHandler : public CallbackInterface_Status {
           dtostrf((value - 61) / 4.0, 0, 2, strtmp);
           output_P(status, PSTR(TOPIC_TROOM), strtmp);
           break;
-        case troom_offset:
-          dtostrf(value/1000.0, 0, 2, strtmp);
-          output_P(status, PSTR(TOPIC_TROOM_OFFSET), strtmp);
-          break;	   
         case status_tsetpoint:
 #ifdef ENHANCED_RESOLUTION
           tmp_value = (value & 0x7f)/ 2.0;

--- a/src/support.h
+++ b/src/support.h
@@ -39,6 +39,10 @@
 //#define POWERON_WHEN_CHANGING_MODE true           // uncomment it to switch on the AC when the mode (heat, cool, dry etc.) is changed
                                                     // used e.g. for home assistant support
 
+//#define ENHANCED_RESOLUTION true                    // when using Tsetpoint with x.5 degrees, airco will use (x+1).0 setpoint
+                                                    // uncomment this to compensatie (offset) Troom for this.
+                                                    // this will simulate .x degrees resolution
+
 // *** The configuration ends here ***
 
 #include <ESP8266WiFi.h>        // https://github.com/esp8266/Arduino/tree/master/libraries/ESP8266WiFi


### PR DESCRIPTION
Added #define ENHANCED_RESOLUTION to enhance the resolution of Tsetpoint when using .5 degrees. To Troom an offset will be added for compensating a higher setpoint if needed. 
Basically the Troom send to the airco will be increased with an offset (0.5 degrees) when a setpoint x.5 degrees is used, to compensate for the setpoint +1 degrees. 
Based on the discussion in issue #81 

Also added #define  DISABLE_FILTER_TROOM to show also Troom delta > 0.0 instead of 0.25 degrees.
Based on the discussion in issue #82 