### PR TITLE
Added Energy used in kWH

### DIFF
--- a/SW-Configuration.md
+++ b/SW-Configuration.md
@@ -195,7 +195,7 @@ if your framework prefers lower case. These topics and payloads are used for MQT
 ## Operating data ([MHI-AC-Ctrl-core.h](src/MHI-AC-Ctrl-core.h))
 Currently the following operating data in double quotes are supported
 ```
-  { 0xc0, 0x94},  //  ? "unknown"
+  { 0xc0, 0x94},  //  0 "energy-used" [kWh]
   { 0xc0, 0x02},  //  1 "MODE"
   { 0xc0, 0x05},  //  2 "SET-TEMP" [°C]
   { 0xc0, 0x80},  //  3 "RETURN-AIR" [°C]
@@ -218,9 +218,11 @@ Currently the following operating data in double quotes are supported
   { 0x00, 0x00},  // dummy
 ```
 
-note: If you are not interested in these operating modes (e.g. to reduce the MQTT load) you can comment out the according lines. But at least the dummy line must be available.
+note1: If you are not interested in these operating modes (e.g. to reduce the MQTT load) you can comment out the according lines. But at least the dummy line must be available.
 For THI-R2, THO-R1 and TDSH the formula for calculation is not yet known.
 You can find some hints related to the meaning of the operating data [here](https://www.hrponline.co.uk/media/pdf/41/42/ed/Beijer-Ref-Service-Support-Handbook-19cWKESQUhzVIy5.pdf#page=7). Addtional opdata infomration is available [here](https://github.com/absalom-muc/MHI-AC-Trace/blob/main/SPI.md#operation-data-details).  
+
+note2: The energy-used is the energy in kWh counting from power on the AC. If you power off the AC, the value (in kWh) will keep the last value. When you power on the AC again, it will start from 0 again.
 
 hint: The error operating data is usually a sub-set of the operating data above. If user requests error operating data, all available error operating data is provided independent from the list above.
 

--- a/Version.md
+++ b/Version.md
@@ -1,5 +1,8 @@
 MHI-AC-Ctrl by absalom-muc
 
+**v2.7R2** (March 2023)
+-  Added energy kWh from airco by [glsf91](https://github.com/glsf91).
+
 **v2.7R1** (February 2023)
 -  Fix for fan not showing 4 and Auto after powerdown AC [pull request #132](https://github.com/absalom-muc/MHI-AC-Ctrl/pull/132#) according to [issue #99](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/99#issuecomment-1407615341) by [glsf91](https://github.com/glsf91).
 

--- a/src/MHI-AC-Ctrl-core.cpp
+++ b/src/MHI-AC-Ctrl-core.cpp
@@ -21,7 +21,7 @@ void MHI_AC_Ctrl_Core::reset_old_values() {  // used e.g. when MQTT connection t
   status_errorcode_old = 0xff;
 
   // old operating data
-  op_0x94_old = 0xff;
+  op_kwh_old = 0xffff;
   op_mode_old = 0xff;
   op_settemp_old = 0xff;
   op_return_air_old = 0xff;
@@ -255,12 +255,12 @@ int MHI_AC_Ctrl_Core::loop(int max_time_ms) {
     bool MOSI_type_opdata = (MOSI_frame[DB10] & 0x30) == 0x10;
 
     switch (MOSI_frame[DB9]) {
-      case 0x94:                              // opdata_0x94
+      case 0x94:                              // 0 energy-kwh n * 0.25 kWh used since power on
         if ((MOSI_frame[DB6] & 0x80) != 0) {  // 
           if (MOSI_type_opdata) {
-            if ((MOSI_frame[DB10] != op_0x94_old)) {
-              op_0x94_old = (MOSI_frame[DB10]<<16)+(MOSI_frame[DB11]<<8)+MOSI_frame[DB12];
-              m_cbiStatus->cbiStatusFunction(opdata_0x94, op_0x94_old);
+            if (((MOSI_frame[DB12]<<8)+(MOSI_frame[DB11])) != op_kwh_old) {
+              op_kwh_old = (MOSI_frame[DB12]<<8)+(MOSI_frame[DB11]);
+              m_cbiStatus->cbiStatusFunction(opdata_kwh, op_kwh_old);
             }
           }
           //else

--- a/src/MHI-AC-Ctrl-core.h
+++ b/src/MHI-AC-Ctrl-core.h
@@ -4,7 +4,7 @@
 
 // comment out the data you are not interested, but at least leave the last dummy row
 const byte opdata[][2] PROGMEM = {
-  //{ 0xc0, 0x94},  //  ? "opdata_0x94", background is unknown.
+  { 0xc0, 0x94},  //  0 "energy-used" [kWh]
   { 0xc0, 0x02},  //  1 "MODE"
   { 0xc0, 0x05},  //  2 "SET-TEMP" [°C]
   { 0xc0, 0x80},  //  3 "RETURN-AIR" [°C]
@@ -63,7 +63,7 @@ enum ACType {   // Type enum
 
 enum ACStatus { // Status enum
   status_power = type_status, status_mode, status_fan, status_vanes, status_troom, status_tsetpoint, status_errorcode,
-  opdata_mode = type_opdata, opdata_0x94, opdata_tsetpoint, opdata_return_air, opdata_outdoor, opdata_tho_r1, opdata_iu_fanspeed, opdata_thi_r1, opdata_thi_r2, opdata_thi_r3,
+  opdata_mode = type_opdata, opdata_kwh, opdata_tsetpoint, opdata_return_air, opdata_outdoor, opdata_tho_r1, opdata_iu_fanspeed, opdata_thi_r1, opdata_thi_r2, opdata_thi_r3,
   opdata_ou_fanspeed, opdata_total_iu_run, opdata_total_comp_run, opdata_comp, opdata_ct, opdata_td,
   opdata_tdsh, opdata_protection_no, opdata_defrost, opdata_ou_eev1, opdata_unknown,
   erropdata_mode = type_erropdata, erropdata_tsetpoint, erropdata_return_air, erropdata_thi_r1, erropdata_thi_r2, erropdata_thi_r3,
@@ -101,7 +101,7 @@ class MHI_AC_Ctrl_Core {
     byte status_errorcode_old;
 
     // old operating data
-    byte op_0x94_old;
+    uint16_t op_kwh_old;
     byte op_mode_old;
     byte op_settemp_old;
     byte op_return_air_old;

--- a/src/MHI-AC-Ctrl.h
+++ b/src/MHI-AC-Ctrl.h
@@ -24,7 +24,7 @@
 #define TOPIC_ERRORCODE "Errorcode"
 
 #define TOPIC_UNKNOWN "unknown"
-#define TOPIC_0X94 "OPDATA_0x94"
+#define TOPIC_KWH "KWH"
 #define TOPIC_RETURNAIR "RETURN-AIR"
 #define TOPIC_THI_R1 "THI-R1"
 #define TOPIC_THI_R2 "THI-R2"

--- a/src/MHI-AC-Ctrl.ino
+++ b/src/MHI-AC-Ctrl.ino
@@ -221,9 +221,9 @@ class StatusHandler : public CallbackInterface_Status {
               break;
           }
           break;
-        case opdata_0x94:
-          itoa(value, strtmp, 10);
-          output_P(status, PSTR(TOPIC_0X94), strtmp);
+        case opdata_kwh:
+          dtostrf(highByte(value)*64.0f + lowByte(value)*0.25f, 0, 2, strtmp);
+          output_P(status, PSTR(TOPIC_KWH), strtmp);
           break;
         case opdata_unknown:
           itoa(value, strtmp, 10);


### PR DESCRIPTION
Hi
I discovered the { 0xc0, 0x94} is used for retrieving the used energy in kWh. So I changed the code to add this.
There will be a new topic 'OpData/KWH' for this.
Important: This item is counting the kWh from the point where the AC is powered On (for example On/Off on the RC). When you power off the AC, it will keep the last value when the AC was on. When you power on the AC again, the counter will start from 0 again. The resolution will be increments in 0.25 kWh.
This is the same behavior as when using the MHI APP en WF-RAC module.

I'm powering of the AC every day. So I could not test what happens if the counter will reach > 64kWh. I expect the high byte (MOSI_frame[DB12]) will be increased with 1 for every additional 64 kWh.
I will create an issue and will ask if somebody (which is using the AC 24 hours a day) can test this.

I also noticed when using high power (Watt) for a longer time there is a difference between this counter and using a separate energy meter. With low  power it is more accurate. Same as with the MHI App.

I think also https://github.com/absalom-muc/MHI-AC-Trace/blob/main/SPI.md should be changed to include this.