### PR TITLE
Change MISO sending and avoid jitter and some fixes

### DIFF
--- a/Version.md
+++ b/Version.md
@@ -1,5 +1,13 @@
 MHI-AC-Ctrl by absalom-muc
 
+**v2.7R3** (March 2023)
+-  fix some compiler warnings by [glsf91](https://github.com/glsf91)
+-  change sending MISO with faster refresh of data every 20s by [glsf91](https://github.com/glsf91)
+-  avoid jitter with internal temperature sensor, now updating atmost every 5s by [glsf91](https://github.com/glsf91)
+-  fix print wifi encryption type by [glsf91](https://github.com/glsf91)
+-  skip not usable values for DB18B20 by [glsf91](https://github.com/glsf91)
+
+
 **v2.7R2** (March 2023)
 -  Added energy kWh from airco by [glsf91](https://github.com/glsf91).
 

--- a/src/MHI-AC-Ctrl-core.h
+++ b/src/MHI-AC-Ctrl-core.h
@@ -2,9 +2,8 @@
 
 #include <Arduino.h>
 
-// comment out the data you are not interested, but at least leave the last dummy row
+// comment out the data you are not interested, but at least leave one row !
 const byte opdata[][2] PROGMEM = {
-  { 0xc0, 0x94},  //  0 "energy-used" [kWh]
   { 0xc0, 0x02},  //  1 "MODE"
   { 0xc0, 0x05},  //  2 "SET-TEMP" [°C]
   { 0xc0, 0x80},  //  3 "RETURN-AIR" [°C]
@@ -24,11 +23,13 @@ const byte opdata[][2] PROGMEM = {
   { 0x40, 0x0c},  // 36 "DEFROST"
   { 0x40, 0x1e},  // 37 "TOTAL-COMP-RUN" [h]
   { 0x40, 0x13},  // 38 "OU-EEV" [Puls]
-  { 0x00, 0x00},  // dummy
+  { 0xc0, 0x94},  //    "energy-used" [kWh]
+
 };
 
-#define NoFramesPerPacket 20                 // number of frames/packet, must be an even number
-
+//#define NoFramesPerPacket 20                 // number of frames/packet, must be an even number
+#define NoFramesPerOpDataCycle 400             // number of frames used for a OpData request cycle; will be 20s (20 frames are 1s)
+#define minTimeInternalTroom 5000              // minimal time in ms used for Troom internal sensor changes for publishing to avoid jitter 
 
 // pin defintions
 #define SCK_PIN  14
@@ -143,7 +144,7 @@ class MHI_AC_Ctrl_Core {
 
     void init();                          // initialization called once after boot
     void reset_old_values();              // resets the 'old' variables ensuring that all status information are resend
-    int loop(int max_time_ms);            // receive / transmit a frame of 20 bytes
+    int loop(uint max_time_ms);            // receive / transmit a frame of 20 bytes
     void set_power(boolean power);        // power on/off the AC
     void set_mode(ACMode mode);           // change AC mode (e.g. heat, dry, cool etc.)
     void set_tsetpoint(uint tsetpoint);   // set the target temperature of the AC)

--- a/src/MHI-AC-Ctrl.ino
+++ b/src/MHI-AC-Ctrl.ino
@@ -158,7 +158,9 @@ class StatusHandler : public CallbackInterface_Status {
   public:
     void cbiStatusFunction(ACStatus status, int value) {
       char strtmp[10];
+#ifdef POWERON_WHEN_CHANGING_MODE
       static int mode_tmp = 0xff;
+#endif
 #ifdef ENHANCED_RESOLUTION      
       float offset = mhi_ac_ctrl_core.get_troom_offset();
       float tmp_value;
@@ -197,7 +199,9 @@ class StatusHandler : public CallbackInterface_Status {
           }
           break;
         case status_mode:
+#ifdef POWERON_WHEN_CHANGING_MODE        
           mode_tmp = value;
+#endif          
         case opdata_mode:
         case erropdata_mode:
           switch (value) {

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -81,7 +81,7 @@ void setupWiFi(int& WiFiStatus) {
     Serial.printf("setupWiFi:%i access points available\n", networksFound);
     for (uint i = 0; i < networksFound; i++)
     {
-      Serial.printf("%2d %25s %2d %ddBm %s %s %02x\n", i + 1, WiFi.SSID(i).c_str(), WiFi.channel(i), WiFi.RSSI(i), WiFi.BSSIDstr(i).c_str(), WiFi.encryptionType(i) == ENC_TYPE_NONE ? "open" : "secured"), (uint)WiFi.encryptionType(i);
+      Serial.printf("%2d %25s %2d %ddBm %s %s %02x\n", i + 1, WiFi.SSID(i).c_str(), WiFi.channel(i), WiFi.RSSI(i), WiFi.BSSIDstr(i).c_str(), WiFi.encryptionType(i) == ENC_TYPE_NONE ? "open" : "secured", (uint)WiFi.encryptionType(i));
       if((strcmp(WiFi.SSID(i).c_str(), WIFI_SSID) == 0) && (WiFi.RSSI(i)>max_rssi)){
           max_rssi = WiFi.RSSI(i);
           strongest_AP = i;
@@ -222,6 +222,9 @@ byte getDs18x20Temperature(int temp_hysterese) {
   if (millis() - DS1820Millis > TEMP_MEASURE_PERIOD * 1000) {
     int16_t tempR = sensors.getTemp(insideThermometer);
     tempR += ROOM_TEMP_DS18X20_OFFSET*128;
+    if (tempR > (48*128) || tempR < (-10*128)) {    // skip onrealistic values
+      tempR = tempR_old;    // use previous value
+    }
     int16_t tempR_diff = tempR - tempR_old; // avoid using other functions inside the brackets of abs, see https://www.arduino.cc/reference/en/language/functions/math/abs/
     if (abs(tempR_diff) > temp_hysterese) {
       tempR_old = tempR;

--- a/src/support.h
+++ b/src/support.h
@@ -3,7 +3,7 @@
 #include "MHI-AC-Ctrl-core.h"
 #include "MHI-AC-Ctrl.h"
 
-#define VERSION "2.7R2"
+#define VERSION "2.7R3"
 
 #define WIFI_SSID ""
 #define WIFI_PASSWORD ""


### PR DESCRIPTION
- fix some compiler warnings by [glsf91](https://github.com/glsf91)
-  change sending MISO with faster refresh of data every 20s by [glsf91](https://github.com/glsf91)
-  avoid jitter with internal temperature sensor, now updating atmost every 5s by [glsf91](https://github.com/glsf91)
-  fix print wifi encryption type by [glsf91](https://github.com/glsf91)
-  skip not usable values for DB18B20 by [glsf91](https://github.com/glsf91)