### PR TITLE
Add SRC35ZSA-W to supported model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ I assume that all AC units of the type "SRK xx ZS-S" / "SRC xx ZS-S" are support
 - [SRK xx ZSX-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/6#issuecomment-582242372)
 - [SRK xx ZSX-W](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-643748095)
 - [SRK xx ZS-W](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/121)
+- [SRC 35Z SA-W]
 
 Unsupported models:
 - [SRK71ZEA-S1](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/143)


### PR DESCRIPTION
I've built and installed several of these units from the Gerber files on the website via JLCPCB and have full functionality with this model.

I'm using it via the [ginkage ESPHome repo](https://github.com/ginkage/MHI-AC-Ctrl-ESPHome).

Specific notes (for anyone who finds this) - I was able to use this [D1 Mini V4.0.0 clone](https://www.aliexpress.com/item/32651747570.html) as the controller, and built with the TSR 1-2450E. I excluded capacitor C1 and haven't had any
problems so far.

For installation I went with a cable extending the connector down the wiring chase, and found the module could be wrapped in electrical tape and tucked in under the main cover which gives plenty of space. 150mm - 200mm wiring seems best.

![image](https://github.com/absalom-muc/MHI-AC-Ctrl/assets/772445/13fba24a-1e15-47cf-bc3a-033122bb0e29)

It works great, the design is great and just wanted to give some feedback in appreciation for the work on this - it's been pretty much plug and play. Absolutely top quality work!