### PR TITLE
Add alternate supported model numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ I assume that all AC units of the type "SRK xx ZS-S" / "SRC xx ZS-S" are support
 - [SRK xx ZM-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/9)
 - [SRK xx ZJX-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-646469621)
 - [SRK xx ZJX-S1](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-646968940)
-- [SRK xx ZRA-W](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-730628655)
-- [SRK xx ZSA-W](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-891649495)
+- [SRK xx ZRA-W](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-730628655) / DXK xx ZRA-W
+- [SRK xx ZSA-W](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-891649495) / DXK xx ZSA-W
 - [SRK xx ZSPR-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/149)
 - [SRK xx ZSX-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/6#issuecomment-582242372)
 - [SRK xx ZSX-W](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-643748095)


### PR DESCRIPTION
This updates the README with alternate model codes for the same series of split systems (called Avanti and Bronte in AU).

I've personally been using this with these model codes for a few months now and can confirm they're the same units as the already known supported ones:

`DXK xx ZSA-W` (same as `SRK xx ZSA-W`)
`DXK xx ZRA-W` (same as `SRK xx ZRA-W`)

These are just the new naming convention (In Australia at least) for the newer revisions of the `SRK` models. The installation guides are even named e.g. `SRKDXK-ZSA-W-series-Installation-Manual`.