### PR TITLE
Add note about loss of timer functionality in troubleshooting

### DIFF
--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -24,6 +24,8 @@ MHI-AC-Ctrl doesn't support all functions of the infrared remote control. This i
 - Vanes up/down is supported, but with the limitation that if the last command was issued by the IR RC, then the vanes up/down status is not visible in MHI-AC-Ctrl
 - ECO, Silent and Night set back mode
 
+Connecting the WiFi controller will **disable** the remote timer functionality. See [here](https://forums.whirlpool.net.au/archive/35qmk853) for more information.
+
 This should be considered especially when you use the IR RC in parallel to MHI-AC-Ctrl.
 
 ## :fire: ESP8266 crashes periodically

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -24,9 +24,9 @@ MHI-AC-Ctrl doesn't support all functions of the infrared remote control. This i
 - Vanes up/down is supported, but with the limitation that if the last command was issued by the IR RC, then the vanes up/down status is not visible in MHI-AC-Ctrl
 - ECO, Silent and Night set back mode
 
-Connecting the WiFi controller will **disable** the remote timer functionality. See [here](https://forums.whirlpool.net.au/archive/35qmk853) for more information.
-
 This should be considered especially when you use the IR RC in parallel to MHI-AC-Ctrl.
+
+Connecting the MHI-AC-Ctrl controller will **disable** the RC timer functionality. This also apply to the standard MHI WiFi (or other) controller. See [here](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/148) for more information.
 
 ## :fire: ESP8266 crashes periodically
 For a periodic crash there are different causes possible:


### PR DESCRIPTION
I wondered if I had some something odd, but found others with a similar model that had the same experience swapping to WiFi.

My way around this will be to configure a timer in HomeAssistant that when it reaches 0, will send an off command to the AC.