### PR TITLE
Move from unmaintained knolleary/pubsubclient to hmueller01/pubsubclient3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ The ESP8266 SPI signals SCL (SPI clock), MOSI (Master Out Slave In) and MISO (Ma
 More details are described in [Hardware.md](Hardware.md).
 
 ## Software:
-The program uses the following libraries
- - :warning:[MQTT client library](https://github.com/knolleary/pubsubclient) - please don't use v2.8.0! (because of this [issue](https://github.com/knolleary/pubsubclient/issues/747)). Better use v2.7.0 :warning:
+The program uses the following libraries:
+ - MQTT client library [PubSubClient3](https://github.com/hmueller01/pubsubclient3)
+   - :warning: Don't use PubSubClient v2.8.0, it is broken due to issue [#747](https://github.com/knolleary/pubsubclient/issues/747) :warning:
  - [ArduinoOTA](https://github.com/esp8266/Arduino/tree/master/libraries/ArduinoOTA) (might be removed in future)
  
 and optionally you need for the use of an external temperature sensor DS18x20 the libraries

--- a/SW-Configuration.md
+++ b/SW-Configuration.md
@@ -33,7 +33,7 @@ Configure the time interval for searching a stronger AP.
 ```
  
 ## MQTT ([support.h](src/support.h))
-The program uses the [MQTT client library](https://github.com/knolleary/pubsubclient) from Nick O'Leary (knolleary).
+The program uses the MQTT client library [PubSubClient3](https://github.com/hmueller01/pubsubclient3) from Holger Müller (hmueller01), originally written by Nick O'Leary (knolleary).
 If you are not familiar with MQTT you find on the Internet endless numbers of descriptions and tutorials. My favorites are [here](https://www.hivemq.com/blog/how-to-get-started-with-mqtt/) and [here](https://www.heise.de/developer/artikel/Kommunikation-ueber-MQTT-3238975.html).
 I recommend [MQTT Explorer](http://mqtt-explorer.com/) a great all-round MQTT client that provides a structured topic overview for the first steps.
 

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -51,7 +51,7 @@ If MISO frequency>10Hz the program will stop and reboot. This prevents damage of
 For reference: With a multimeter I measure for SCK and MOSI approx. 4.7V on the HV pins of the level shifter (and X1) and approx. 3V on the LV pins of the level shifter (and D5/D7)
 
 ### :fire: You use PubSubClient v2.8.0
-There was a [bug](https://github.com/knolleary/pubsubclient/issues/747) introduced in PubSubClient version 2.8.0, please use v2.7.0.
+There was a [bug](https://github.com/knolleary/pubsubclient/issues/747) introduced in PubSubClient version 2.8.0. Please use [PubSubClient3](https://github.com/hmueller01/pubsubclient3) instead, or downgrade to PubSubClient v2.7.0.
 
 ## :fire: MQTT connects / disconnects periodically
 The HOSTNAME specified in support.h is used as WiFi hostname, MQTT hostname and OTA hostname. In case that you use more than one MHI-AC-Ctrl, e.g. in a multi-split configuration, you have to use unique HOSTNAME to every PCB.

--- a/src/support.h
+++ b/src/support.h
@@ -56,7 +56,7 @@
 // *** The configuration ends here ***
 
 #include <ESP8266WiFi.h>        // https://github.com/esp8266/Arduino/tree/master/libraries/ESP8266WiFi
-#include <PubSubClient.h>       // https://github.com/knolleary/pubsubclient
+#include <PubSubClient.h>       // https://github.com/hmueller01/pubsubclient3
 #include <ArduinoOTA.h>         // https://github.com/esp8266/Arduino/tree/master/libraries/ArduinoOTA
 
 #if TEMP_MEASURE_PERIOD > 0


### PR DESCRIPTION
As stated in the [README](https://github.com/absalom-muc/MHI-AC-Ctrl#software), the latest version 2.8.0 of PubSubClient is broken, and it is very unlikely that the fix PR https://github.com/knolleary/pubsubclient/pull/1020 will ever be merged.

The library is unmaintained. This is officially confirmed by the author in https://github.com/knolleary/pubsubclient/issues/1045. There are some maintained forks, though. An up-to-date and maintained fork containing all outstanding fixes is https://github.com/hmueller01/pubsubclient3. It is available in the Arduino IDE under the distinct name PubSubClient3, while the code is backwards-compatible.

The currently recommended workaround is to downgrade PubSubClient to 2.7.0. I suggest to use PubSubClient3 instead. This would save developers from accidently updating the library PubSubClient to broken version 2.8.0.