### PR TITLE
Add validated support for SRF xx ZS-W series to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ I assume that all AC units of the type "SRK xx ZS-S" / "SRC xx ZS-S" are support
 - [SRF xx ZMX-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-704789297)
 - [SRF xx ZMXA-S](https://github.com/absalom-muc/MHI-AC-Ctrl/pull/91)
 - SRF xx ZF-W
+- [SRF xx ZS-W]() works with frame size 20
 - [SRK xx ZJ-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/10)
 - [SRK xx ZM-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/9)
 - [SRK xx ZJX-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-646469621)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I assume that all AC units of the type "SRK xx ZS-S" / "SRC xx ZS-S" are support
 - [SRF xx ZMX-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-704789297)
 - [SRF xx ZMXA-S](https://github.com/absalom-muc/MHI-AC-Ctrl/pull/91)
 - SRF xx ZF-W
-- [SRF xx ZS-W]() works with frame size 20
+- [SRF xx ZS-W](https://github.com/absalom-muc/MHI-AC-Ctrl/pull/216#issue-3234769567) works with frame size 20
 - [SRK xx ZJ-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/10)
 - [SRK xx ZM-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/9)
 - [SRK xx ZJX-S](https://github.com/absalom-muc/MHI-AC-Ctrl/issues/17#issuecomment-646469621)


### PR DESCRIPTION
I validated that this works on an SRF25ZS-W unit. It requires the frame size to be set to 20 to work.